### PR TITLE
Use same base commit from fixup for rebasing

### DIFF
--- a/index.md
+++ b/index.md
@@ -210,7 +210,7 @@ git checkout README.md # shortcut for git checkout HEAD README.md
 git config --global rebase.autostash true
 git config --global rebase.autosquash true
 git commit --fixup b9acf57
-git rebase --interactive 6aa1c74 # git rebase -i for short
+git rebase --interactive b9acf57^1 # git rebase -i for short
 ```
 <img src="./autosquash.png" alt="autosquash in action" />
 


### PR DESCRIPTION
Instead of knowing two differents commits, it is probably 
better to use the same commit for theses two commands.