### PR TITLE
Add missing branch name

### DIFF
--- a/index.md
+++ b/index.md
@@ -164,7 +164,7 @@ git branch -d main
 ```
 Need to start a new branch?
 ```shell
-git switch --create origin/main
+git switch --create new-branch origin/main
 ```
 Need to test something on "main"?
 ```shell


### PR DESCRIPTION
That's an embarassing mistake, the previous version results in a branch literally named origin/main being created. 😬